### PR TITLE
feat!: `Rut::random_in_range` and remove `unwrap`s on `random_*` associated

### DIFF
--- a/crates/rutcl/Cargo.toml
+++ b/crates/rutcl/Cargo.toml
@@ -20,6 +20,10 @@ name = "rutcl"
 
 [dependencies]
 thiserror = "1.0.56"
+rand = "0.8.5"
+
+# [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+# rand = { version = "0.8.5", features = ["js"] }
 
 # Optional Dependencies
 serde = { version = "1.0.197", optional = true }

--- a/crates/rutcl/Cargo.toml
+++ b/crates/rutcl/Cargo.toml
@@ -25,9 +25,6 @@ thiserror = "1.0.56"
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.197", optional = true }
 
-# [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-# rand = { version = "0.8.5", optional = true, features = ["js"] }
-
 [dev-dependencies]
 csv = "1.3.0"
 serde_test = "1.0.176"

--- a/crates/rutcl/Cargo.toml
+++ b/crates/rutcl/Cargo.toml
@@ -11,26 +11,23 @@ keywords = ["rutcl", "chile", "national", "nid", "parser"]
 license = "MIT"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 name = "rutcl"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+serde = ["dep:serde"]
+rand = ["dep:rand"]
 
 [dependencies]
 thiserror = "1.0.56"
-rand = "0.8.5"
-
-# [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-# rand = { version = "0.8.5", features = ["js"] }
 
 # Optional Dependencies
+rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.197", optional = true }
+
+# [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+# rand = { version = "0.8.5", optional = true, features = ["js"] }
 
 [dev-dependencies]
 csv = "1.3.0"
 serde_test = "1.0.176"
-
-[features]
-serde = ["dep:serde"]

--- a/crates/rutcl/src/lib.rs
+++ b/crates/rutcl/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use std::cmp::Ordering;
 use std::collections::hash_map::RandomState;
 use std::fmt::Display;
@@ -276,12 +279,21 @@ impl Rut {
     }
 
     /// Generates a random [`Rut`] instance.
-    pub fn random() -> Self {
+    pub fn random() -> Result<Self, Error> {
         let hasher = RandomState::new().build_hasher();
         let num = hasher.finish() as u32 % MAX_NUM;
-        let vd = VerificationDigit::new(num).unwrap();
+        let vd = VerificationDigit::new(num)?;
 
-        Rut(num, vd)
+        Ok(Rut(num, vd))
+    }
+
+    /// Generates a random [`Rut`] instance inside the provided range.
+    pub fn random_in_range() -> Result<Self, Error> {
+        let hasher = RandomState::new().build_hasher();
+        let num = hasher.finish() as u32 % MAX_NUM;
+        let vd = VerificationDigit::new(num)?;
+
+        Ok(Rut(num, vd))
     }
 
     /// Return the RUT's number ([`Num`]) without the [`VerificationDigit`]
@@ -454,265 +466,5 @@ impl<'de> Deserialize<'de> for Rut {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_str(RutVisitor)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use csv::ReaderBuilder;
-
-    #[cfg(feature = "serde")]
-    use serde::de::value::{Error as ValueError, StrDeserializer, StringDeserializer};
-    #[cfg(feature = "serde")]
-    use serde::de::IntoDeserializer;
-    #[cfg(feature = "serde")]
-    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
-
-    use super::*;
-
-    const SAMPLES: &str = include_str!("../../../fixtures/samples.csv");
-
-    struct Sample {
-        rut: String,
-        num: String,
-        vd: String,
-    }
-
-    fn samples() -> Vec<Sample> {
-        let mut reader = ReaderBuilder::new().from_reader(SAMPLES.as_bytes());
-
-        reader
-            .records()
-            .map(|record| {
-                let record = record.unwrap();
-                Sample {
-                    rut: record[0].to_string(),
-                    num: record[1].to_string(),
-                    vd: record[2].to_string(),
-                }
-            })
-            .collect::<Vec<Sample>>()
-    }
-
-    #[test]
-    fn calculates_verification_digit() {
-        let units = vec![
-            (75_303_649, VerificationDigit::Zero),
-            (27_388_094, VerificationDigit::One),
-            (27_962_409, VerificationDigit::Two),
-            (98_127_523, VerificationDigit::Three),
-            (30_686_957, VerificationDigit::Four),
-            (45_022_275, VerificationDigit::Five),
-            (61_570_639, VerificationDigit::Six),
-            (59_608_778, VerificationDigit::Seven),
-            (43_496_204, VerificationDigit::Eight),
-            (70_059_381, VerificationDigit::Nine),
-            (92_635_843, VerificationDigit::K),
-            (super::MIN_NUM, VerificationDigit::Nine),
-            (super::MAX_NUM, VerificationDigit::Nine),
-        ];
-
-        for (number, expected) in units {
-            let vd = VerificationDigit::new(number).unwrap();
-            assert_eq!(vd, expected, "Expected: {:?}, Got: {:?}", expected, vd);
-        }
-    }
-
-    #[test]
-    fn parses_rut_from_string() {
-        let samples = samples();
-
-        samples.iter().for_each(|Sample { rut, num, vd }| {
-            let rut = Rut::from_str(rut).unwrap();
-            assert_eq!(rut.num(), num.parse::<Num>().unwrap());
-            assert_eq!(rut.vd(), VerificationDigit::from_str(vd).unwrap());
-            assert_eq!(rut.to_string(), format!("{}{}", num, vd));
-        });
-    }
-
-    #[test]
-    fn random_never_repeats() {
-        let mut ruts = vec![];
-
-        for _ in 0..100 {
-            let rut = Rut::random();
-            assert!(!ruts.contains(&rut));
-            ruts.push(rut);
-        }
-    }
-
-    #[test]
-    fn associated_fn_max() {
-        assert_eq!(Rut::max(), MAX);
-    }
-
-    #[test]
-    fn associated_fn_min() {
-        assert_eq!(Rut::min(), MIN);
-    }
-
-    #[test]
-    fn parses_min_rut() {
-        let string = MIN.to_string();
-        assert_eq!(Rut::from_str(&string).unwrap(), MIN);
-    }
-
-    #[test]
-    fn parses_max_rut() {
-        let string = MAX.to_string();
-        assert_eq!(Rut::from_str(&string).unwrap(), MAX);
-    }
-
-    #[test]
-    fn format_sans_rut_value() {
-        let have = "17.951.585-7";
-        let want = "179515857";
-        let rut = Rut::from_str(have).unwrap();
-
-        assert_eq!(rut.format(Format::Sans), want);
-    }
-
-    #[test]
-    fn format_dash_rut_value() {
-        let have = "17.951.585-7";
-        let want = "17951585-7";
-        let rut = Rut::from_str(have).unwrap();
-
-        assert_eq!(rut.format(Format::Dash), want);
-    }
-
-    #[test]
-    fn format_dots_rut_value() {
-        let cases = vec![
-            ("179515857", "17.951.585-7"),
-            ("75.303.649-0", "75.303.649-0"),
-            ("273880941", "27.388.094-1"),
-            ("27962409-2", "27.962.409-2"),
-            ("98127523-3", "98.127.523-3"),
-            ("30.686.957-4", "30.686.957-4"),
-            ("450222755", "45.022.275-5"),
-            ("615706396", "61.570.639-6"),
-            ("59.608.778-7", "59.608.778-7"),
-            ("43496204-8", "43.496.204-8"),
-            ("700593819", "70.059.381-9"),
-            ("92635843K", "92.635.843-K"),
-        ];
-
-        for (have, want) in cases {
-            let rut = Rut::from_str(have).unwrap();
-            assert_eq!(rut.format(Format::Dots), want);
-        }
-    }
-
-    #[test]
-    fn format_dots_rut_min() {
-        let rut = MIN;
-        assert_eq!(rut.format(Format::Dots), "1.000.000-9");
-    }
-
-    #[test]
-    fn format_dots_rut_max() {
-        let rut = MAX;
-        assert_eq!(rut.format(Format::Dots), "99.999.999-9");
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn serialize_rut_instance() {
-        let rut = Rut::from_str("92.635.843-K").unwrap();
-
-        assert_tokens(&rut, &[Token::Str("92635843K")]);
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn deserialize_rut_as_str() {
-        let rut: StrDeserializer<ValueError> = "450222755".into_deserializer();
-        let rut = rut.deserialize_str(RutVisitor);
-
-        assert_eq!(rut, Ok(Rut(45022275, VerificationDigit::Five)));
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn deserialize_rut_as_string() {
-        let rut: StringDeserializer<ValueError> = String::from("450222755").into_deserializer();
-        let rut = rut.deserialize_string(RutVisitor);
-
-        assert_eq!(rut, Ok(Rut(45022275, VerificationDigit::Five)));
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn deserialize_rut_as_err_invalid_str() {
-        assert_de_tokens_error::<Rut>(
-            &[Token::Str("ThisIsNotARut")],
-            "Provided string is not a number. invalid digit found in string",
-        )
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn deserialize_rut_as_err_empty() {
-        assert_de_tokens_error::<Rut>(&[Token::Str("")], "The provided string is empty")
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn deserialize_rut_as_err() {
-        assert_de_tokens_error::<Rut>(
-            &[Token::Str("1.111.111-1")],
-            "Invalid verification digit: have 1, want 4",
-        )
-    }
-
-    #[test]
-    fn compares_ruts() {
-        let ruts = vec![
-            ("1326658-1", "15441715-K"),
-            ("15441715-K", "29718958-1"),
-            ("29718958-1", "30088687-6"),
-            ("30088687-6", "45278657-5"),
-            ("45278657-5", "58175019-6"),
-            ("58175019-6", "63990386-9"),
-            ("63990386-9", "77992926-4"),
-            ("77992926-4", "80919766-2"),
-            ("80919766-2", "94577430-4"),
-        ];
-
-        for (rut_a, rut_b) in ruts {
-            assert!(
-                Rut::from_str(rut_a).unwrap() < Rut::from_str(rut_b).unwrap(),
-                "{rut_a} should be lower than {rut_b}"
-            );
-            assert!(
-                Rut::from_str(rut_b).unwrap() > Rut::from_str(rut_a).unwrap(),
-                "{rut_b} should be greather than {rut_a}"
-            );
-        }
-    }
-
-    #[test]
-    fn compares_equal_ruts() {
-        let ruts = vec![
-            ("15441715-K", "15441715-K", true),
-            ("15441715-K", "29718958-1", false),
-            ("30088687-6", "30088687-6", true),
-            ("30088687-6", "45278657-5", false),
-        ];
-
-        for (rut_a, rut_b, expect) in ruts {
-            assert_eq!(
-                Rut::from_str(rut_a).unwrap() == Rut::from_str(rut_b).unwrap(),
-                expect
-            );
-        }
-    }
-
-    #[test]
-    fn support_lowercase_k() {
-        let rut = Rut::from_str("15441715-k").expect("Should build RUT instance");
-
-        assert_eq!(rut.1, VerificationDigit::K);
     }
 }

--- a/crates/rutcl/src/lib.rs
+++ b/crates/rutcl/src/lib.rs
@@ -12,9 +12,10 @@ use std::str::FromStr;
 #[cfg(feature = "serde")]
 use std::fmt;
 
-use rand::distributions::uniform::SampleRange;
-use rand::{thread_rng, Rng};
 use thiserror::Error;
+
+#[cfg(feature = "rand")]
+use rand::distributions::uniform::SampleRange;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -289,8 +290,11 @@ impl Rut {
         Ok(Rut(num, vd))
     }
 
+    #[cfg(feature = "rand")]
     /// Generates a random [`Rut`] instance inside the provided range.
     pub fn random_in_range<R: SampleRange<u32>>(range: R) -> Result<Self, Error> {
+        use rand::{thread_rng, Rng};
+
         let num = thread_rng().gen_range(range);
         let vd = VerificationDigit::new(num)?;
 

--- a/crates/rutcl/src/lib.rs
+++ b/crates/rutcl/src/lib.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 #[cfg(feature = "serde")]
 use std::fmt;
 
+use rand::distributions::uniform::SampleRange;
+use rand::{thread_rng, Rng};
 use thiserror::Error;
 
 #[cfg(feature = "serde")]
@@ -288,9 +290,8 @@ impl Rut {
     }
 
     /// Generates a random [`Rut`] instance inside the provided range.
-    pub fn random_in_range() -> Result<Self, Error> {
-        let hasher = RandomState::new().build_hasher();
-        let num = hasher.finish() as u32 % MAX_NUM;
+    pub fn random_in_range<R: SampleRange<u32>>(range: R) -> Result<Self, Error> {
+        let num = thread_rng().gen_range(range);
         let vd = VerificationDigit::new(num)?;
 
         Ok(Rut(num, vd))

--- a/crates/rutcl/src/tests.rs
+++ b/crates/rutcl/src/tests.rs
@@ -256,6 +256,7 @@ fn support_lowercase_k() {
 }
 
 #[test]
+#[cfg(feature = "rand")]
 fn generates_random_in_range() {
     let mut prevs = Vec::with_capacity(100);
 

--- a/crates/rutcl/src/tests.rs
+++ b/crates/rutcl/src/tests.rs
@@ -254,3 +254,27 @@ fn support_lowercase_k() {
 
     assert_eq!(rut.1, VerificationDigit::K);
 }
+
+#[test]
+fn generates_random_in_range() {
+    let mut prevs = Vec::with_capacity(100);
+
+    for i in 0..100 {
+        let rut = Rut::random_in_range(10_000_000..15_000_000).unwrap();
+        assert!(
+            !prevs.contains(&rut),
+            "RUT: {:?} (Number {}) was generated before within a max of 100 iterations, current iteration {}",
+            rut,
+            rut.0,
+            i + 1,
+        );
+        prevs.push(rut);
+        assert!(
+            10_000_000 <= rut.0 && rut.0 <= 15_000_000,
+            "RUT: {:?} (Number {}) outbounds range, current iteration {}",
+            rut,
+            rut.0,
+            i + 1,
+        );
+    }
+}

--- a/crates/rutcl/src/tests.rs
+++ b/crates/rutcl/src/tests.rs
@@ -1,0 +1,256 @@
+use csv::ReaderBuilder;
+
+#[cfg(feature = "serde")]
+use serde::de::value::{Error as ValueError, StrDeserializer, StringDeserializer};
+#[cfg(feature = "serde")]
+use serde::de::IntoDeserializer;
+#[cfg(feature = "serde")]
+use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+use super::*;
+
+const SAMPLES: &str = include_str!("../../../fixtures/samples.csv");
+
+struct Sample {
+    rut: String,
+    num: String,
+    vd: String,
+}
+
+fn samples() -> Vec<Sample> {
+    let mut reader = ReaderBuilder::new().from_reader(SAMPLES.as_bytes());
+
+    reader
+        .records()
+        .map(|record| {
+            let record = record.unwrap();
+            Sample {
+                rut: record[0].to_string(),
+                num: record[1].to_string(),
+                vd: record[2].to_string(),
+            }
+        })
+        .collect::<Vec<Sample>>()
+}
+
+#[test]
+fn calculates_verification_digit() {
+    let units = vec![
+        (75_303_649, VerificationDigit::Zero),
+        (27_388_094, VerificationDigit::One),
+        (27_962_409, VerificationDigit::Two),
+        (98_127_523, VerificationDigit::Three),
+        (30_686_957, VerificationDigit::Four),
+        (45_022_275, VerificationDigit::Five),
+        (61_570_639, VerificationDigit::Six),
+        (59_608_778, VerificationDigit::Seven),
+        (43_496_204, VerificationDigit::Eight),
+        (70_059_381, VerificationDigit::Nine),
+        (92_635_843, VerificationDigit::K),
+        (super::MIN_NUM, VerificationDigit::Nine),
+        (super::MAX_NUM, VerificationDigit::Nine),
+    ];
+
+    for (number, expected) in units {
+        let vd = VerificationDigit::new(number).unwrap();
+        assert_eq!(vd, expected, "Expected: {:?}, Got: {:?}", expected, vd);
+    }
+}
+
+#[test]
+fn parses_rut_from_string() {
+    let samples = samples();
+
+    samples.iter().for_each(|Sample { rut, num, vd }| {
+        let rut = Rut::from_str(rut).unwrap();
+        assert_eq!(rut.num(), num.parse::<Num>().unwrap());
+        assert_eq!(rut.vd(), VerificationDigit::from_str(vd).unwrap());
+        assert_eq!(rut.to_string(), format!("{}{}", num, vd));
+    });
+}
+
+#[test]
+fn random_never_repeats() {
+    let mut ruts = vec![];
+
+    for _ in 0..100 {
+        let rut = Rut::random().unwrap();
+        assert!(!ruts.contains(&rut));
+        ruts.push(rut);
+    }
+}
+
+#[test]
+fn associated_fn_max() {
+    assert_eq!(Rut::max(), MAX);
+}
+
+#[test]
+fn associated_fn_min() {
+    assert_eq!(Rut::min(), MIN);
+}
+
+#[test]
+fn parses_min_rut() {
+    let string = MIN.to_string();
+    assert_eq!(Rut::from_str(&string).unwrap(), MIN);
+}
+
+#[test]
+fn parses_max_rut() {
+    let string = MAX.to_string();
+    assert_eq!(Rut::from_str(&string).unwrap(), MAX);
+}
+
+#[test]
+fn format_sans_rut_value() {
+    let have = "17.951.585-7";
+    let want = "179515857";
+    let rut = Rut::from_str(have).unwrap();
+
+    assert_eq!(rut.format(Format::Sans), want);
+}
+
+#[test]
+fn format_dash_rut_value() {
+    let have = "17.951.585-7";
+    let want = "17951585-7";
+    let rut = Rut::from_str(have).unwrap();
+
+    assert_eq!(rut.format(Format::Dash), want);
+}
+
+#[test]
+fn format_dots_rut_value() {
+    let cases = vec![
+        ("179515857", "17.951.585-7"),
+        ("75.303.649-0", "75.303.649-0"),
+        ("273880941", "27.388.094-1"),
+        ("27962409-2", "27.962.409-2"),
+        ("98127523-3", "98.127.523-3"),
+        ("30.686.957-4", "30.686.957-4"),
+        ("450222755", "45.022.275-5"),
+        ("615706396", "61.570.639-6"),
+        ("59.608.778-7", "59.608.778-7"),
+        ("43496204-8", "43.496.204-8"),
+        ("700593819", "70.059.381-9"),
+        ("92635843K", "92.635.843-K"),
+    ];
+
+    for (have, want) in cases {
+        let rut = Rut::from_str(have).unwrap();
+        assert_eq!(rut.format(Format::Dots), want);
+    }
+}
+
+#[test]
+fn format_dots_rut_min() {
+    let rut = MIN;
+    assert_eq!(rut.format(Format::Dots), "1.000.000-9");
+}
+
+#[test]
+fn format_dots_rut_max() {
+    let rut = MAX;
+    assert_eq!(rut.format(Format::Dots), "99.999.999-9");
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn serialize_rut_instance() {
+    let rut = Rut::from_str("92.635.843-K").unwrap();
+
+    assert_tokens(&rut, &[Token::Str("92635843K")]);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn deserialize_rut_as_str() {
+    let rut: StrDeserializer<ValueError> = "450222755".into_deserializer();
+    let rut = rut.deserialize_str(RutVisitor);
+
+    assert_eq!(rut, Ok(Rut(45022275, VerificationDigit::Five)));
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn deserialize_rut_as_string() {
+    let rut: StringDeserializer<ValueError> = String::from("450222755").into_deserializer();
+    let rut = rut.deserialize_string(RutVisitor);
+
+    assert_eq!(rut, Ok(Rut(45022275, VerificationDigit::Five)));
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn deserialize_rut_as_err_invalid_str() {
+    assert_de_tokens_error::<Rut>(
+        &[Token::Str("ThisIsNotARut")],
+        "Provided string is not a number. invalid digit found in string",
+    )
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn deserialize_rut_as_err_empty() {
+    assert_de_tokens_error::<Rut>(&[Token::Str("")], "The provided string is empty")
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn deserialize_rut_as_err() {
+    assert_de_tokens_error::<Rut>(
+        &[Token::Str("1.111.111-1")],
+        "Invalid verification digit: have 1, want 4",
+    )
+}
+
+#[test]
+fn compares_ruts() {
+    let ruts = vec![
+        ("1326658-1", "15441715-K"),
+        ("15441715-K", "29718958-1"),
+        ("29718958-1", "30088687-6"),
+        ("30088687-6", "45278657-5"),
+        ("45278657-5", "58175019-6"),
+        ("58175019-6", "63990386-9"),
+        ("63990386-9", "77992926-4"),
+        ("77992926-4", "80919766-2"),
+        ("80919766-2", "94577430-4"),
+    ];
+
+    for (rut_a, rut_b) in ruts {
+        assert!(
+            Rut::from_str(rut_a).unwrap() < Rut::from_str(rut_b).unwrap(),
+            "{rut_a} should be lower than {rut_b}"
+        );
+        assert!(
+            Rut::from_str(rut_b).unwrap() > Rut::from_str(rut_a).unwrap(),
+            "{rut_b} should be greather than {rut_a}"
+        );
+    }
+}
+
+#[test]
+fn compares_equal_ruts() {
+    let ruts = vec![
+        ("15441715-K", "15441715-K", true),
+        ("15441715-K", "29718958-1", false),
+        ("30088687-6", "30088687-6", true),
+        ("30088687-6", "45278657-5", false),
+    ];
+
+    for (rut_a, rut_b, expect) in ruts {
+        assert_eq!(
+            Rut::from_str(rut_a).unwrap() == Rut::from_str(rut_b).unwrap(),
+            expect
+        );
+    }
+}
+
+#[test]
+fn support_lowercase_k() {
+    let rut = Rut::from_str("15441715-k").expect("Should build RUT instance");
+
+    assert_eq!(rut.1, VerificationDigit::K);
+}

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -20,7 +20,7 @@ leptos = { version = "0.6", features = ["csr"] }
 leptos_meta = { version = "0.6", features = ["csr"] }
 
 # Local Dependencies
-rutcl = { path = "../rutcl" }
+rutcl = { path = "../rutcl", features = ["rand"] }
 
 [dev-dependencies]
 wasm-bindgen = "0.2"

--- a/crates/web/src/components/navbar.rs
+++ b/crates/web/src/components/navbar.rs
@@ -12,6 +12,7 @@ pub fn NavBar() -> impl IntoView {
                 <a class="link" href="/#installation">Installation</a>
                 <span class="section-divider">Usage</span>
                 <a class="link" href="/#create-rut">Create RUT</a>
+                <a class="link" href="/#random-in-range-rut">Random in Range RUT</a>
             </nav>
             <footer class="h-[60px] bg-zinc-950 absolute p-4 bottom-0 w-full">
                 <small class="text-xs text-center block text-gray-400">

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -16,16 +16,16 @@ pub fn App() -> impl IntoView {
     provide_meta_context();
 
     view! {
-        <Title text="RUT Chile | Chilean National ID (RUT) Parser for Rust"/>
+        <Title text="RUT Chile | Chilean National ID (RUT) Parser for Rust" />
         <div class="grid md:grid-cols-[250px,auto] bg-zinc-950 text-gray-50 min-h-screen">
-            <NavBar/>
+            <NavBar />
             <div class="h-screen oveflow-hidden">
-                <Header/>
+                <Header />
                 <main class="h-[calc(100vh-60px)] overflow-y-scroll">
-                    <Hero/>
-                    <Motivation/>
-                    <Installation/>
-                    <CreateRut/>
+                    <Hero />
+                    <Motivation />
+                    <Installation />
+                    <CreateRut />
                 </main>
             </div>
         </div>

--- a/crates/web/src/sections/create_rut.rs
+++ b/crates/web/src/sections/create_rut.rs
@@ -6,9 +6,11 @@ use crate::components::section::Section;
 #[component]
 pub fn CreateRut() -> impl IntoView {
     let (random_rut_reader, random_rut_writer) = create_signal(Rut::random());
+    let (random_in_range_reader, random_in_range_writer) = create_signal(Rut::random_in_range(10_000_000..15_000_000).unwrap());
 
     let randomize = move |_| {
         random_rut_writer.set(Rut::random());
+        random_in_range_writer.set(Rut::random_in_range(10_000_000..15_000_000).unwrap());
     };
 
     view! {
@@ -24,6 +26,15 @@ pub fn CreateRut() -> impl IntoView {
             </code>
             <h3>Example</h3>
                 <p class="bg-gray-900 p-4 font-mono rounded-md shadow-md mb-4">{move || random_rut_reader.get().unwrap().format(Format::Dots)}</p>
+            <button type="button" on:click={randomize}>Generate</button>
+        </Section>
+        <Section title="Random in Range">
+            <p>Random RUT values can also be created within a range using the <code>Rut::random_in_range()</code> associated function.</p>
+            <code class="my-4">
+                let rut = Rut::random_in_range(10_000_000..15_000_000);
+            </code>
+            <h3>Example</h3>
+                <p class="bg-gray-900 p-4 font-mono rounded-md shadow-md mb-4">{move || random_in_range_reader.get().format(Format::Dots)}</p>
             <button type="button" on:click={randomize}>Generate</button>
         </Section>
     }

--- a/crates/web/src/sections/create_rut.rs
+++ b/crates/web/src/sections/create_rut.rs
@@ -23,7 +23,7 @@ pub fn CreateRut() -> impl IntoView {
                 let rut = Rut::random();
             </code>
             <h3>Example</h3>
-                <p class="bg-gray-900 p-4 font-mono rounded-md shadow-md mb-4">{move || random_rut_reader.get().format(Format::Dots)}</p>
+                <p class="bg-gray-900 p-4 font-mono rounded-md shadow-md mb-4">{move || random_rut_reader.get().unwrap().format(Format::Dots)}</p>
             <button type="button" on:click={randomize}>Generate</button>
         </Section>
     }


### PR DESCRIPTION
Introduces a `Rut::random_in_range` associated method and removes `unwrap`s from `random` generators. This introduces a code breakage because now `random_*` associated functions returns `Result` instead.